### PR TITLE
chore: Update the example to use sidecar from the start

### DIFF
--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -33,38 +33,46 @@
    "execution_count": 2,
    "id": "8ef3a29d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0299875a115143f7abff5cc21e553c4b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "UnfoldedMap(mapUUID='ae4f5345-8507-49ec-85f6-a1f8c7bc2219')"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "my_map = UnfoldedMap(mapUUID='ae4f5345-8507-49ec-85f6-a1f8c7bc2219')\n",
-    "my_map"
+    "my_map = UnfoldedMap(mapUUID='ae4f5345-8507-49ec-85f6-a1f8c7bc2219')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e50723f-9853-4d8f-a61d-d1e3b651c1b9",
+   "metadata": {},
+   "source": [
+    "We can use the [`jupyterlab-sidecar`](https://github.com/jupyter-widgets/jupyterlab-sidecar) package to display the map in JupyterLab's sidebar."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "79a5845c-d90a-42c4-9803-636d490e0bbe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sidecar import Sidecar\n",
+    "\n",
+    "sc = Sidecar(title='Unfolded Map', anchor='split-right')\n",
+    "with sc:\n",
+    "    display(my_map)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "8768bd3f",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "After waiting for the map to finish loading, we can issue commands to the map:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "a99965e2",
    "metadata": {},
    "outputs": [],
@@ -82,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "da367624",
    "metadata": {},
    "outputs": [],
@@ -101,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "20a537fe",
    "metadata": {},
    "outputs": [
@@ -111,7 +119,7 @@
        "[Layer(label='Point', id='25smxo6', is_visible=True)]"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -130,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "723a7ef3",
    "metadata": {},
    "outputs": [
@@ -140,7 +148,7 @@
        "<Future pending>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -152,7 +160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "4f146a01",
    "metadata": {},
    "outputs": [
@@ -162,7 +170,7 @@
        "<Future pending>"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -182,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "92d9b429",
    "metadata": {},
    "outputs": [
@@ -192,7 +200,7 @@
        "<Future pending>"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -213,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "61d9fe8c",
    "metadata": {},
    "outputs": [],
@@ -224,84 +232,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "828bbbfb",
    "metadata": {},
    "outputs": [],
    "source": [
     "my_map.set_theme('dark')"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f90ac8cf",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "## Viewing map in sidebar\n",
-    "\n",
-    "We can also use the [`jupyterlab-sidecar`](https://github.com/jupyter-widgets/jupyterlab-sidecar) package to display the map in JupyterLab's sidebar."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "f9324080",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sidecar import Sidecar"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "3022665b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sc = Sidecar(title='Unfolded Map', anchor='split-right')\n",
-    "with sc:\n",
-    "    display(my_map)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c97e9921",
-   "metadata": {},
-   "source": [
-    "Now when we issue commands to the map, the map in the sidebar will be updated:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "b8866297",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Future pending>"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "my_map.set_layer_visibility(layer_id=layer.id, is_visible=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b6d84af8",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -320,7 +257,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I updated the example to use Sidecar from the start so that the user can see how you can interact with the map without scrolling on top.

<img width="1790" alt="Screenshot 2021-05-07 at 17 08 23" src="https://user-images.githubusercontent.com/7241522/117470204-d75a4e00-af56-11eb-815c-5d212199bf9c.png">
