### PR TITLE
Add readme to notebooks

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,10 @@
+# Map SDK examples for Jupyter
+
+[![Binder][binder_badge]][binder_jupyterlab_url]
+
+This is a collection of example notebooks which illustrate the use of [Unfolded Map SDK](https://docs.unfolded.ai/map-sdk) in Jupyter.
+
+Please note that it takes some time for the Jupyter environment on Binder to load and start in the browser. Once it is loaded you can fully interact with the examples.
+
+[binder_badge]: https://mybinder.org/badge_logo.svg
+[binder_jupyterlab_url]: https://mybinder.org/v2/gh/UnfoldedInc/examples/master?urlpath=lab/tree/notebooks/


### PR DESCRIPTION
Since we have links to the GitHub page for the `notebooks` directory in the docs, I think it makes sense to add a readme.

![image](https://user-images.githubusercontent.com/351828/121900165-6bbd8a80-cd25-11eb-8e15-63559f79932b.png)
