### PR TITLE
Fix: Missing React import

### DIFF
--- a/map-sdk/react/react-basic-example/src/App.js
+++ b/map-sdk/react/react-basic-example/src/App.js
@@ -1,4 +1,4 @@
-import {useState, useRef, useEffect} from 'react';
+import React, {useState, useRef, useEffect} from 'react';
 import {createMap, setViewState, getLayers, setLayerVisibility} from '@unfolded/map-sdk';
 
 import './App.scss';


### PR DESCRIPTION
The app fails to load on [StackBlitz](https://stackblitz.com/github/UnfoldedInc/examples/tree/master/map-sdk/react/react-basic-example) because of that